### PR TITLE
Fix util.lua (hidden networks in range)

### DIFF
--- a/ffho/ffho-autoupdater-wifi-fallback/luasrc/usr/lib/lua/autoupdater-wifi-fallback/util.lua
+++ b/ffho/ffho-autoupdater-wifi-fallback/luasrc/usr/lib/lua/autoupdater-wifi-fallback/util.lua
@@ -16,8 +16,10 @@ function get_available_wifi_networks()
     if iw then
       local list = iw.scanlist(radio)
       for _, net in ipairs(list) do
-        if net.ssid:match('.*[Ff][Rr][Ee][Ii][Ff][Uu][Nn][Kk].*') then
-          return radio, net.ssid, net.bssid
+        if net.ssid and net.bssid then
+          if net.ssid:match('.*[Ff][Rr][Ee][Ii][Ff][Uu][Nn][Kk].*') then
+            return radio, net.ssid, net.bssid
+          end
         end
       end
     end


### PR DESCRIPTION
If there is a hidden network in range it will have a 'nil' SSID value and the match function will result in an error aborting the updater.
This commit also checks for the bssid value so that if the bssid gathering whyever fails it doesn't let the whole updater fail.
