### PR TITLE
Update ath9k-blackout-workaround

### DIFF
--- a/ffho/ffho-ath9k-blackout-workaround/luasrc/usr/sbin/ath9k-blackout-workaround
+++ b/ffho/ffho-ath9k-blackout-workaround/luasrc/usr/sbin/ath9k-blackout-workaround
@@ -15,18 +15,19 @@ end
 
 function devOk (iface)
   local data = uci:get_all('wireless', iface)
-  if data.disabled then
+  if data.disabled == 1 then
     return null
   end
-  local radio = uci:get_all('wireless', data.radio)
-  if not radio.hwmode == '11g' or radio.disabled then
+  local radio = uci:get_all('wireless', data.device)
+  if not radio.hwmode == '11g' or radio.disabled == 1 then
     return null
   end
-  local wifitype = iwinfo.type(data.radio)
-  local iw = iwinfo[wifitype]
-  if iw.assoclist(iface) then
-    return true
-  end
+  local wifitype = iwinfo.type(data.device)
+  local iw = iwinfo[wifitype].assoclist(iface)
+  if iw then
+    if #iw > 0 then
+      return true
+    end
   return false
 end
 


### PR DESCRIPTION
It didn't work for me otherwise... In our fork of your workaround we have added several tests etc. The code isn't really clean, yet, but you can have a look:
https://github.com/FFEssen/packages/blob/2.2.1/ffe-ath9k-blackout-workaround/luasrc/usr/sbin/ath9k-blackout-workaround