### PR TITLE
Fix ffho-ath9k-blackout-workaround

### DIFF
--- a/ffho/ffho-ath9k-blackout-workaround/ReadMe.md
+++ b/ffho/ffho-ath9k-blackout-workaround/ReadMe.md
@@ -8,10 +8,10 @@ site.conf
 ---------
 
 **ath9k-workaround.blackout_wait:**
-- minimum delay to detect a possible blackout as blackout
+- minimum delay in minutes to detect a possible blackout as blackout
 
 **ath9k-workaround.reset_wait:**
-- minimum delay between reset
+- minimum delay in minutes between reset
 
 **ath9k-workaround.step_size**
 - execute the cronjob each x minutes

--- a/ffho/ffho-ath9k-blackout-workaround/ReadMe.md
+++ b/ffho/ffho-ath9k-blackout-workaround/ReadMe.md
@@ -7,19 +7,19 @@ we try to detect problems and restart the wifi.
 site.conf
 ---------
 
-**ath9k-workaround.blackout_wait:**
+**ath9k_workaround.blackout_wait:**
 - minimum delay in minutes to detect a possible blackout as blackout
 
-**ath9k-workaround.reset_wait:**
+**ath9k_workaround.reset_wait:**
 - minimum delay in minutes between reset
 
-**ath9k-workaround.step_size**
+**ath9k_workaround.step_size**
 - execute the cronjob each x minutes
 
 ### example
 ```lua
 {
-  ath9k-workaround = {
+  ath9k_workaround = {
     blackout_wait = 720,
     reset_wait = 1440,
     step_size = 10,

--- a/ffho/ffho-ath9k-blackout-workaround/luasrc/usr/sbin/ath9k-blackout-workaround
+++ b/ffho/ffho-ath9k-blackout-workaround/luasrc/usr/sbin/ath9k-blackout-workaround
@@ -54,8 +54,8 @@ if check_wifi() or not fs.readfile(fileOk) then
   os.exit(0)
 end
 
-local blackout_wait_secs = site.ath9k-workaround.blackout_wait *60
-local reset_wait_secs = site.ath9k-workaround.reset_wait *60
+local blackout_wait_secs = site.ath9k_workaround.blackout_wait *60
+local reset_wait_secs = site.ath9k_workaround.reset_wait *60
 
 if os.difftime(os.time(), tonumber(fs.readfile(fileReset))) <= reset_wait_secs then
   os.exit(0)

--- a/ffho/ffho-ath9k-blackout-workaround/luasrc/usr/sbin/ath9k-blackout-workaround
+++ b/ffho/ffho-ath9k-blackout-workaround/luasrc/usr/sbin/ath9k-blackout-workaround
@@ -14,7 +14,7 @@ function time2file (file)
 end
 
 function devOk (iface)
-  local radio = uci:get_all('wireless', iface, 'radio')
+  local radio = uci:get_all('wireless', iface, 'device')
   local disabled = uci:get_bool('wireless', iface, 'disabled') or uci:get_bool('wireless', radio, 'disabled')
   if disabled then
     return null


### PR DESCRIPTION
This PR consists of 3 commits from which only one is a fix for the script to work properly. Till now the scripts tries to find the radio name in `wireless.radio_name.radio` but it is `wireless.radio_name.device`.

A second problem I encountered is that the site.conf section needs to named `ath9k-workaround` but the normal naming convention for site.conf variables is with an underscore. As it is set to `ath9k_workaround` in the site [ffho](https://git.c3pb.de/freifunk-pb/site-ffho/blob/stable/extra/template.conf#L237) I consider this as a bug.

The third and last commit just clarifies that all values are minutes.

A backport to v2016.2.x would also be necessary as this branch has the same problems.