### PR TITLE
Cleanup hidden network exception

### DIFF
--- a/ffho/ffho-autoupdater-wifi-fallback/luasrc/usr/lib/lua/autoupdater-wifi-fallback/util.lua
+++ b/ffho/ffho-autoupdater-wifi-fallback/luasrc/usr/lib/lua/autoupdater-wifi-fallback/util.lua
@@ -19,8 +19,10 @@ function get_available_wifi_networks()
 	end
     local tmplist = iw.scanlist(radio)
     for _, net in ipairs(tmplist) do
-      if net.ssid and net.bssid and net.ssid:match('.*[Ff][Rr][Ee][Ii][Ff][Uu][Nn][Kk].*') then
-        table.insert (radios[radio], net)
+      if net.ssid and net.bssid then
+	if net.ssid:match('.*[Ff][Rr][Ee][Ii][Ff][Uu][Nn][Kk].*') then
+          table.insert (radios[radio], net)
+	end
       end
     end
   end


### PR DESCRIPTION
Look at:
f2d9cebf2adcea96d7daaecd5a46e50c2f5b5b56

If there is a hidden network in range it will have a 'nil' SSID value and the match function will result in an error aborting the updater.