### PR TITLE
2018.1.x: string-based path specifications in site check scripts have…

### DIFF
--- a/ffho/ffho-ath9k-blackout-workaround/check_site.lua
+++ b/ffho/ffho-ath9k-blackout-workaround/check_site.lua
@@ -1,3 +1,3 @@
-need_number('ath9k_workaround.blackout_wait')
-need_number('ath9k_workaround.reset_wait')
-need_number('ath9k_workaround.step_size')
+need_number({'ath9k_workaround', 'blackout_wait'})
+need_number({'ath9k_workaround', 'reset_wait'})
+need_number({'ath9k_workaround', 'step_size'})


### PR DESCRIPTION
… been replaced with arrays

see https://gluon.readthedocs.io/en/v2018.1.x/releases/v2018.1.html#site-changes

I think you have to create a new branch to merge this into