### PR TITLE
Added - as allowed character for the domain name

### DIFF
--- a/ffho-autoupdater-wifi-fallback/luasrc/usr/lib/lua/autoupdater-wifi-fallback/util.lua
+++ b/ffho-autoupdater-wifi-fallback/luasrc/usr/lib/lua/autoupdater-wifi-fallback/util.lua
@@ -33,7 +33,7 @@ function get_update_hosts(branch)
   local mirrors = uci:get_list('autoupdater', branch, 'mirror')
 
   for _, mirror in ipairs(mirrors) do
-    local host = mirror:match('://%[?([a-zA-Z0-9\:\.]+)%]?/')
+    local host = mirror:match('://%[?([a-zA-Z0-9\-\:\.]+)%]?/')
     table.insert(hosts, 1, host)
   end
   return hosts


### PR DESCRIPTION
If you have freifunk-westerwald.de in example, the pattern is not matching corretly